### PR TITLE
feat(admin-settings): implement configurable admin settings system

### DIFF
--- a/.idea/CryptoTrade.iml
+++ b/.idea/CryptoTrade.iml
@@ -3,7 +3,6 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/app/core" isTestSource="false" packagePrefix="CryptoTrade\" />
-      <sourceFolder url="file://$MODULE_DIR$/app/spec" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/app/vendor/composer" />
       <excludeFolder url="file://$MODULE_DIR$/app/vendor/firebase/php-jwt" />
       <excludeFolder url="file://$MODULE_DIR$/app/vendor/graham-campbell/result-type" />

--- a/app/core/Controllers/AdminSettingController.php
+++ b/app/core/Controllers/AdminSettingController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace CryptoTrade\Controllers;
+
+use CryptoTrade\Services\AdminSettingService;
+use CryptoTrade\Services\JWTService;
+use CryptoTrade\Services\CSRFService;
+use Exception;
+
+class AdminSettingController
+{
+    private AdminSettingService $adminSettingService;
+
+    public function __construct()
+    {
+        $this->adminSettingService = new AdminSettingService();
+    }
+
+    public function getAll(): void
+    {
+        $this->requirePost();
+
+        try {
+            CSRFService::verifyToken($_POST['csrf_token'] ?? '');
+            JWTService::verifyJWT();
+
+            $settings = $this->adminSettingService->getAllSettings();
+            echo json_encode(['success' => true, 'settings' => $settings]);
+        } catch (Exception $e) {
+            $this->sendError($e);
+        }
+    }
+
+    public function update(): void
+    {
+        $this->requirePost();
+
+        try {
+            CSRFService::verifyToken($_POST['csrf_token'] ?? '');
+            JWTService::verifyJWT();
+
+            $key = $_POST['setting_key'] ?? null;
+            $value = $_POST['setting_value'] ?? null;
+
+            if (!$key || $value === null) {
+                throw new Exception("Missing setting_key or setting_value.");
+            }
+
+            $this->adminSettingService->updateSetting($key, $value);
+            echo json_encode(['success' => true, 'message' => 'Setting updated.']);
+            // JS redirect to /admin-settings
+            echo "<script>window.location.href = '/admin-settings';</script>";
+        } catch (Exception $e) {
+            $this->sendError($e);
+        }
+    }
+
+    public function delete(): void
+    {
+        $this->requirePost();
+
+        try {
+            CSRFService::verifyToken($_POST['csrf_token'] ?? '');
+            JWTService::verifyJWT();
+
+            $key = $_POST['setting_key'] ?? null;
+            if (!$key) {
+                throw new Exception("Missing setting_key.");
+            }
+
+            $this->adminSettingService->deleteSetting($key);
+            echo json_encode(['success' => true, 'message' => 'Setting deleted.']);
+            // JS redirect to /admin-settings
+            echo "<script>window.location.href = '/admin-settings';</script>";
+        } catch (Exception $e) {
+            $this->sendError($e);
+        }
+    }
+
+    private function requirePost(): void
+    {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+            exit;
+        }
+    }
+
+    private function sendError(Exception $e): void
+    {
+        echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+    }
+}

--- a/app/core/DataAccess/AdminSettingRepository.php
+++ b/app/core/DataAccess/AdminSettingRepository.php
@@ -6,7 +6,7 @@ use CryptoTrade\Models\AdminSettings;
 
 class AdminSettingRepository extends Repository
 {
-    protected function __construct()
+    public function __construct()
     {
         parent::__construct();
         $this->table = "admin_settings";
@@ -27,17 +27,17 @@ class AdminSettingRepository extends Repository
         return AdminSettings::fromArray(parent::get_by_id($id));
     }
 
-    public function createAdminSetting(AdminSettings $adminSetting)
+    public function createAdminSetting(AdminSettings $adminSetting): void
     {
         parent::insert($adminSetting->toArray());
     }
 
-    public function updateAdminSetting(AdminSettings $adminSetting)
+    public function updateAdminSetting(AdminSettings $adminSetting): void
     {
         parent::update($adminSetting->toArray());
     }
 
-    public function deleteAdminSetting(AdminSettings $adminSetting)
+    public function deleteAdminSetting(AdminSettings $adminSetting): void
     {
         parent::delete($adminSetting->id);
     }

--- a/app/core/Services/AdminSettingService.php
+++ b/app/core/Services/AdminSettingService.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace CryptoTrade\Services;
+
+use CryptoTrade\DataAccess\AdminSettingRepository;
+use CryptoTrade\Models\AdminSettings;
+
+class AdminSettingService
+{
+    private AdminSettingRepository $adminSettingRepo;
+
+    public function __construct()
+    {
+        $this->adminSettingRepo = new AdminSettingRepository();
+    }
+
+    public function getAllSettings(): array
+    {
+        return $this->adminSettingRepo->getAllAdminSettings();
+    }
+
+    public function getSettingValue(string $key, $default = null): ?string
+    {
+        foreach ($this->getAllSettings() as $setting) {
+            if ($setting->setting_key === $key) {
+                return $setting->setting_value;
+            }
+        }
+
+        return $default;
+    }
+
+    public function updateSetting(string $key, string $value): void
+    {
+        foreach ($this->getAllSettings() as $setting) {
+            if ($setting->setting_key === $key) {
+                $setting->setting_value = $value;
+                $this->adminSettingRepo->updateAdminSetting($setting);
+                return;
+            }
+        }
+
+        $newSetting = new AdminSettings(0, $key, $value);
+        $this->adminSettingRepo->createAdminSetting($newSetting);
+    }
+
+    public function deleteSetting(string $key): void
+    {
+        foreach ($this->getAllSettings() as $setting) {
+            if ($setting->setting_key === $key) {
+                $this->adminSettingRepo->deleteAdminSetting($setting);
+                return;
+            }
+        }
+    }
+}

--- a/app/route.php
+++ b/app/route.php
@@ -37,6 +37,8 @@ return [
 
 
     // ---------------------------- USER API ROUTES (PSR-4 autoloaded) ----------------------------
+    //**IMPORTANT**: the user API routes are prefixed with "api/user" to avoid conflicts with other APIs
+    // format controller@functions is a convention used in the project (parsed by the custom-made router)
 
     // Public API Routes (No JWT Required)
     'api/user/register' => 'CryptoTrade\Controllers\UserController@register',
@@ -102,6 +104,12 @@ return [
     'api/user/alerts/getByUserId' => 'CryptoTrade\Controllers\AlertController@getByUserId',
     'api/user/alerts/update' => 'CryptoTrade\Controllers\AlertController@update',
     'api/user/alerts/toggle' => 'CryptoTrade\Controllers\AlertController@toggleStatus',
+
+    // ---------------------------- ADMIN SETTINGS API ROUTES (PSR-4 autoloaded) ----------------------------
+    'api/admin/settings/getAll' => 'CryptoTrade\Controllers\AdminSettingController@getAll',
+    'api/admin/settings/update' => 'CryptoTrade\Controllers\AdminSettingController@update',
+    'api/admin/settings/delete' => 'CryptoTrade\Controllers\AdminSettingController@delete',
+
 
 ];
 

--- a/app/views/components/navbar.php
+++ b/app/views/components/navbar.php
@@ -56,6 +56,7 @@ if (isset($_SESSION['jwt'])) {
 
                     <li><a href="user-wallet" class="spa-link">Wallet</a></li>
                     <li><a href="user-market" class="spa-link">Market</a></li>
+                    <li><a href="user-payment" class="spa-link">Payment</a></li>
                     <li><a href="user-history" class="spa-link">History</a></li>
                     <li><a href="user-alerts" class="spa-link">Alerts</a></li>
                     <li><a href="user-report" class="spa-link">Report</a></li>

--- a/app/views/pages_admin/payments.php
+++ b/app/views/pages_admin/payments.php
@@ -1,2 +1,2 @@
-<?php
+<?php //admin-payment
 // View Stripe payment history

--- a/app/views/pages_admin/settings.php
+++ b/app/views/pages_admin/settings.php
@@ -1,2 +1,89 @@
 <?php
-// Update platform settings (e.g., max transactions/day)
+use CryptoTrade\Services\AdminSettingService;
+
+$csrfToken = $_SESSION['csrf_token'] ?? '';
+$service = new AdminSettingService();
+$settings = $service->getAllSettings();
+
+// Optional: descriptive tooltips for settings
+$settingTooltips = [
+    'max_transactions_per_day'       => 'Maximum number of transactions a user can make per day.',
+    'min_deposit_amount'             => 'Minimum USD amount required for a deposit.',
+    '2fa_required'                   => 'Require two-factor authentication for user login.',
+    'auto_sell_threshold_percentage' => 'Trigger auto-sell when crypto drops below this percentage.',
+    'invitation_required'            => 'Require an invitation token to register.',
+    'initial_account_balance_usd'    => 'USD balance assigned to new user accounts.',
+    'price_update_interval'          => 'Seconds between crypto price simulation updates.',
+    'audit_log_retention_days'       => 'Number of days to retain audit logs.',
+    'max_failed_logins'              => 'Number of failed logins before lockout.',
+    'stripe_test_mode'               => 'Enable test mode for Stripe payments.'
+];
+?>
+
+<h2>Admin Settings</h2>
+
+<table border="1" cellpadding="8" cellspacing="0">
+    <thead>
+    <tr>
+        <th>Setting Key</th>
+        <th>Value</th>
+        <th>Update</th>
+        <th>Delete</th>
+    </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($settings as $setting): ?>
+        <tr>
+            <!-- Update Form -->
+            <form method="POST" action="api/admin/settings/update">
+                <td title="<?= htmlspecialchars($settingTooltips[$setting->setting_key] ?? '') ?>">
+                    <?= htmlspecialchars($setting->setting_key) ?>
+                </td>
+                <td>
+                    <?php
+                    $val = strtolower($setting->setting_value);
+                    $isBool = in_array($val, ['true', 'false'], true);
+                    ?>
+                    <?php if ($isBool): ?>
+                        <label>
+                            <input type="radio" name="setting_value" value="true" <?= $val === 'true' ? 'checked' : '' ?>> true
+                        </label>
+                        <label>
+                            <input type="radio" name="setting_value" value="false" <?= $val === 'false' ? 'checked' : '' ?>> false
+                        </label>
+                    <?php else: ?>
+                        <input type="text" name="setting_value" value="<?= htmlspecialchars($setting->setting_value) ?>">
+                    <?php endif; ?>
+                    <input type="hidden" name="setting_key" value="<?= htmlspecialchars($setting->setting_key) ?>">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                </td>
+                <td>
+                    <button type="submit">Update</button>
+                </td>
+            </form>
+
+            <!-- Delete Form -->
+            <form method="POST" action="api/admin/settings/delete">
+                <td>
+                    <input type="hidden" name="setting_key" value="<?= htmlspecialchars($setting->setting_key) ?>">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+                    <button type="submit" onclick="return confirm('Are you sure you want to delete this setting?')">Delete</button>
+                </td>
+            </form>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+
+<!-- Add New Setting -->
+<h3>Add New Setting</h3>
+<form method="POST" action="api/admin/settings/update">
+    <label>Key:
+        <input type="text" name="setting_key" required>
+    </label>
+    <label>Value:
+        <input type="text" name="setting_value" required>
+    </label>
+    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken) ?>">
+    <button type="submit">Add</button>
+</form>

--- a/app/views/pages_user/payment.php
+++ b/app/views/pages_user/payment.php
@@ -1,2 +1,2 @@
-<?php
+<?php //user-payment
 // Buy platform credits via Stripe (test mode)

--- a/db/init.sql
+++ b/db/init.sql
@@ -188,10 +188,18 @@ VALUES
 (3, 5, 'buy', 5.00, 120.00);
 
 -- Insert Sample Admin Settings
-INSERT INTO admin_settings (setting_key, setting_value)
-VALUES
+INSERT INTO admin_settings (setting_key, setting_value) VALUES
 ('max_transactions_per_day', '10'),
-('min_deposit_amount', '50');
+('min_deposit_amount', '25.00'),
+('2fa_required', 'true'),
+('auto_sell_threshold_percentage', '-10'),
+('invitation_required', 'true'),
+('initial_account_balance_usd', '1000'),
+('price_update_interval', '1'),
+('audit_log_retention_days', '90'),
+('max_failed_logins', '5'),
+('stripe_test_mode', 'true');
+
 
 -- Insert Sample Alerts
 INSERT INTO alerts (user_id, crypto_id, price_threshold, alert_type, active, created_at, last_triggered_at)


### PR DESCRIPTION
- Created `admin_settings` DB table with initial seed values (e.g., max_transactions_per_day, 2fa_required)
- Implemented AdminSettingService for clean access and updates
- Added AdminSettingController (getAll, update, delete) with CSRF & JWT protection
- Built simple PHP-only admin UI for managing settings (with radio buttons for booleans and tooltips)
- Settings are now ready to be consumed by other components as global platform constants
close #28 